### PR TITLE
Defect/de2004 fix request headers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "typescript.tsdk": "front_end/node_modules/typescript/lib"
+    "typescript.tsdk": "front_end/node_modules/typescript/lib",
+    "editor.tabSize": 2
 }

--- a/front_end/config/karma.conf.js
+++ b/front_end/config/karma.conf.js
@@ -82,7 +82,7 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
+    autoWatch: true,
 
     /*
      * start these browsers
@@ -103,7 +103,7 @@ module.exports = function(config) {
      * Continuous Integration mode
      * if true, Karma captures browsers, runs the tests and exits
      */
-    singleRun: true
+    singleRun: false
   };
 
   if (process.env.TRAVIS){
@@ -111,6 +111,9 @@ module.exports = function(config) {
       'ChromeTravisCi',
       'PhantomJS'
     ];
+
+    configuration.autoWatch = false;
+    configuration.singleRun = true;
   }
 
   config.set(configuration);

--- a/front_end/config/karma.conf.js
+++ b/front_end/config/karma.conf.js
@@ -111,16 +111,13 @@ module.exports = function(config) {
       'ChromeTravisCi',
       'PhantomJS'
     ];
-    
+
     configuration.autoWatch = false;
     configuration.singleRun = true;
   }
 
   if(process.env.TEAMCITY_VERSION) {
-    configuration.reporters = [
-      'mocha',
-      'karma-teamcity-reporter'
-    ]
+    configuration.reporters = [ 'teamcity' ];
 
     configuration.autoWatch = false;
     configuration.singleRun = true;

--- a/front_end/config/karma.conf.js
+++ b/front_end/config/karma.conf.js
@@ -111,6 +111,16 @@ module.exports = function(config) {
       'ChromeTravisCi',
       'PhantomJS'
     ];
+    
+    configuration.autoWatch = false;
+    configuration.singleRun = true;
+  }
+
+  if(process.env.TEAMCITY_VERSION) {
+    configuration.reporters = [
+      'mocha',
+      'karma-teamcity-reporter'
+    ]
 
     configuration.autoWatch = false;
     configuration.singleRun = true;

--- a/front_end/src/app/app.component.spec.ts
+++ b/front_end/src/app/app.component.spec.ts
@@ -13,7 +13,7 @@ describe('App: FrontEnd', () => {
   });
 
   it('should pass a Hello World test', async(() => {
-    expect("clown").toBeTruthy();
+    expect('clown').toBeTruthy();
   }));
 
 });

--- a/front_end/src/app/app.component.ts
+++ b/front_end/src/app/app.component.ts
@@ -11,7 +11,7 @@ export class AppComponent {
 
   private viewContainerRef: ViewContainerRef;
 
-  constructor(private router: Router, viewContainerRef:ViewContainerRef) {
+  constructor(private router: Router, viewContainerRef: ViewContainerRef) {
     // You need this small hack in order to catch application root view container ref
     this.viewContainerRef = viewContainerRef;
   }

--- a/front_end/src/app/shared/services/http-client.service.spec.ts
+++ b/front_end/src/app/shared/services/http-client.service.spec.ts
@@ -1,0 +1,78 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { HttpClientService } from './http-client.service';
+import { Http, RequestOptions, Headers, Response, ResponseOptions } from '@angular/http';
+import { MockConnection, MockBackend } from '@angular/http/testing';
+
+describe('HttpClientService', () => {
+  let fixture: HttpClientService;
+  let http: Http;
+  let options: RequestOptions;
+  let backend: MockBackend;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        HttpClientService
+      ],
+    });
+    backend = new MockBackend();
+    options = new RequestOptions();
+    options.headers = new Headers();
+    http = new Http(backend, options);
+    fixture = new HttpClientService(http);
+  });
+
+  describe('get method', () => {
+    let responseObject = { 'test': 123 };
+    let requestHeaders: Headers;
+    let requestUrl: string;
+    beforeEach(() => {
+      backend.connections.subscribe((connection: MockConnection) => {
+        requestHeaders = connection.request.headers;
+        requestUrl = connection.request.url;
+        connection.mockRespond(new Response(new ResponseOptions({
+          body: responseObject
+        })));
+      });
+    });
+
+    afterEach(() => {
+      backend.resolveAllConnections();
+      backend.verifyNoPendingRequests();
+    });
+
+    it('should call http.get() with proper URL and use existing RequestOptions', () => {
+      options.headers.set('this', 'should still be here');
+      let response = fixture.get('/test/123', options);
+      response.subscribe((res: Response) => {
+        expect(res.json()).toEqual(responseObject);
+        expect(requestHeaders).toBeDefined();
+        expect(requestHeaders).toEqual(options.headers);
+        expect(requestHeaders.get('Content-Type')).toEqual('application/json');
+        expect(requestHeaders.get('Accept')).toEqual('application/json, text/plain, */*');
+        expect(requestHeaders.get('Crds-Api-Key')).toEqual(process.env.ECHECK_API_TOKEN);
+        expect(requestHeaders.get('this')).toEqual('should still be here');
+        expect(requestUrl).toEqual('/test/123');
+      });
+    });
+
+    it('should call http.get() with proper URL and create new RequestOptions', () => {
+      options.headers.set('this', 'should not be here');
+      let response = fixture.get('/test/123');
+      backend.resolveAllConnections();
+      backend.verifyNoPendingRequests();
+      response.subscribe((res: Response) => {
+        expect(res.json()).toEqual(responseObject);
+        expect(requestHeaders).toBeDefined();
+        expect(requestHeaders).not.toEqual(options.headers);
+        expect(requestHeaders.get('Content-Type')).toEqual('application/json');
+        expect(requestHeaders.get('Accept')).toEqual('application/json, text/plain, */*');
+        expect(requestHeaders.get('Crds-Api-Key')).toEqual(process.env.ECHECK_API_TOKEN);
+        expect(requestHeaders.has('this')).toBeFalsy();
+        expect(requestUrl).toEqual('/test/123');
+      });
+    });
+  });
+});

--- a/front_end/src/app/shared/services/http-client.service.spec.ts
+++ b/front_end/src/app/shared/services/http-client.service.spec.ts
@@ -83,5 +83,18 @@ describe('HttpClientService', () => {
         expect(fixture.isLoggedIn()).toBeTruthy();
       });
     });
+
+    it('should send authentication token if logged in', () => {
+      responseObject.userToken = '98765';
+      let response = fixture.get('/test/123');
+      response.subscribe(() => {
+        expect(fixture.isLoggedIn()).toBeTruthy();
+        let r2 = fixture.get('/test/123');
+        r2.subscribe(() => {
+          expect(requestHeaders.has('Authorization')).toBeTruthy();
+          expect(requestHeaders.get('Authorization')).toEqual('98765');
+        });
+      });
+    });
   });
 });

--- a/front_end/src/app/shared/services/http-client.service.spec.ts
+++ b/front_end/src/app/shared/services/http-client.service.spec.ts
@@ -63,8 +63,6 @@ describe('HttpClientService', () => {
     it('should call http.get() with proper URL and create new RequestOptions', () => {
       options.headers.set('this', 'should not be here');
       let response = fixture.get('/test/123');
-      backend.resolveAllConnections();
-      backend.verifyNoPendingRequests();
       response.subscribe((res: Response) => {
         expect(res.json()).toEqual(responseObject);
         expect(requestHeaders).toBeDefined();
@@ -81,8 +79,6 @@ describe('HttpClientService', () => {
     it('should set authentication token if sent in response', () => {
       responseObject.userToken = '98765';
       let response = fixture.get('/test/123');
-      backend.resolveAllConnections();
-      backend.verifyNoPendingRequests();
       response.subscribe(() => {
         expect(fixture.isLoggedIn()).toBeTruthy();
       });

--- a/front_end/src/app/shared/services/http-client.service.spec.ts
+++ b/front_end/src/app/shared/services/http-client.service.spec.ts
@@ -10,6 +10,7 @@ describe('HttpClientService', () => {
   let http: Http;
   let options: RequestOptions;
   let backend: MockBackend;
+  let responseObject: any;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -25,7 +26,7 @@ describe('HttpClientService', () => {
   });
 
   describe('get method', () => {
-    let responseObject = { 'test': 123 };
+    responseObject = { 'test': 123 };
     let requestHeaders: Headers;
     let requestUrl: string;
     beforeEach(() => {
@@ -55,6 +56,7 @@ describe('HttpClientService', () => {
         expect(requestHeaders.get('Crds-Api-Key')).toEqual(process.env.ECHECK_API_TOKEN);
         expect(requestHeaders.get('this')).toEqual('should still be here');
         expect(requestUrl).toEqual('/test/123');
+        expect(fixture.isLoggedIn()).toBeFalsy();
       });
     });
 
@@ -72,6 +74,17 @@ describe('HttpClientService', () => {
         expect(requestHeaders.get('Crds-Api-Key')).toEqual(process.env.ECHECK_API_TOKEN);
         expect(requestHeaders.has('this')).toBeFalsy();
         expect(requestUrl).toEqual('/test/123');
+        expect(fixture.isLoggedIn()).toBeFalsy();
+      });
+    });
+
+    it('should set authentication token if sent in response', () => {
+      responseObject.userToken = '98765';
+      let response = fixture.get('/test/123');
+      backend.resolveAllConnections();
+      backend.verifyNoPendingRequests();
+      response.subscribe(() => {
+        expect(fixture.isLoggedIn()).toBeTruthy();
       });
     });
   });

--- a/front_end/src/app/shared/services/http-client.service.ts
+++ b/front_end/src/app/shared/services/http-client.service.ts
@@ -1,5 +1,6 @@
-import {Injectable} from '@angular/core';
-import {Http, Headers, RequestOptions} from '@angular/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Http, Headers, RequestOptions, Response } from '@angular/http';
 
 @Injectable()
 export class HttpClientService {
@@ -11,17 +12,27 @@ export class HttpClientService {
   }
 
   get(url: string, options?: RequestOptions) {
-    let requestOptions = this.getRequestOption(options)
-    return this.http.get(url, requestOptions);
+    let requestOptions = this.getRequestOption(options);
+    return this.extractAuthToken(this.http.get(url, requestOptions));
   }
 
-  post(url:string, data:any, options?: RequestOptions) {
-    let requestOptions = this.getRequestOption(options)
-    return this.http.post(url, data, requestOptions);
+  post(url: string, data: any, options?: RequestOptions) {
+    let requestOptions = this.getRequestOption(options);
+    return this.extractAuthToken(this.http.post(url, data, requestOptions));
   }
 
   isLoggedIn(): boolean {
     return this.authenticationToken.length > 0;
+  }
+
+  private extractAuthToken(o: Observable<Response>): Observable<Response> {
+    o.subscribe((res: Response) => {
+      let body = res.json();
+      if (body != null && body.userToken) {
+        this.authenticationToken = body.userToken;
+      }
+    });
+    return o;
   }
 
   private getRequestOption(options?: RequestOptions):  RequestOptions {

--- a/front_end/src/app/shared/services/http-client.service.ts
+++ b/front_end/src/app/shared/services/http-client.service.ts
@@ -35,6 +35,7 @@ export class HttpClientService {
     let reqHeaders =  headers || new Headers();
     reqHeaders.set('Authorization', this.authenticationToken);
     reqHeaders.set('Content-Type', 'application/json');
+    reqHeaders.set('Accept', 'application/json, text/plain, */*');
     reqHeaders.set('Crds-Api-Key', process.env.ECHECK_API_TOKEN);
 
     return reqHeaders;


### PR DESCRIPTION
Updated HttpClientService to send Accept header in requests, ensuring that we get JSON back.  We were getting XML back in Firefox and Edge, apparently they add their own Accept headers if none are explicitly specified.