### PR TITLE
DE2257: Specify an exact Date() on Observable.timer

### DIFF
--- a/front_end/src/app/shared/services/user.service.ts
+++ b/front_end/src/app/shared/services/user.service.ts
@@ -28,8 +28,9 @@ export class UserService {
   }
 
   public setUser(user: User): void {
+    let expiration = moment().add(this.SessionLengthMilliseconds, 'milliseconds').toDate();
     let cookieOptions = new CookieOptions();
-    cookieOptions.expires = moment().add(this.SessionLengthMilliseconds, 'milliseconds').toDate();
+    cookieOptions.expires = expiration;
 
     this.cookie.putObject('user', user, cookieOptions);
     if (this.refreshTimeout) {
@@ -38,7 +39,7 @@ export class UserService {
     }
 
     if (user.isLoggedIn()) {
-      this.refreshTimeout = Observable.timer(this.SessionLengthMilliseconds).subscribe(() => {
+      this.refreshTimeout = Observable.timer(expiration).subscribe(() => {
         this.loginRedirectService.redirectToLogin(this.router.routerState.snapshot.url);
       });
     }


### PR DESCRIPTION
Previously was specifying a timeout in milliseconds, but this was being used as an amount of time to wait before emitting, and that amount of time was "paused" when a device went to sleep.  Specifying a Date tells the timer to emit at that exact time (or after that time, if the time passes while a device is asleep).