### PR TITLE
Generate swagger xml doc file for all build configurations

### DIFF
--- a/SignInCheckIn/SignInCheckIn/SignInCheckIn.csproj
+++ b/SignInCheckIn/SignInCheckIn/SignInCheckIn.csproj
@@ -352,6 +352,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+	<DocumentationFile>bin\SignInCheckIn.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Demo|AnyCPU'">
     <OutputPath>bin\</OutputPath>
@@ -361,6 +362,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+	<DocumentationFile>bin\SignInCheckIn.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Label="SlowCheetah">
     <SlowCheetahToolsPath>$([System.IO.Path]::GetFullPath( $(MSBuildProjectDirectory)\..\packages\SlowCheetah.2.5.14\tools\))</SlowCheetahToolsPath>


### PR DESCRIPTION
* [Swagger](https://checkin-gatewayint.crossroads.net/SignInCheckIn/swagger/ui/index) was not working for checkin in integration or demo - I missed those build configs when I added the XML doc generation.
* Added xml doc file to integration and demo