### PR TITLE
defect/DE3455 - Filter out Group Participant Records that are end dated.

### DIFF
--- a/SignInCheckIn/MinistryPlatform.Translation.Test/Repositories/ChildSigninRepositoryTest.cs
+++ b/SignInCheckIn/MinistryPlatform.Translation.Test/Repositories/ChildSigninRepositoryTest.cs
@@ -548,7 +548,7 @@ namespace MinistryPlatform.Translation.Test.Repositories
 
 	    private static string GetChildParticpantsByPrimaryHouseholdFilter(int householdId)
         {
-            return $"Participant_ID_Table_Contact_ID_Table_Household_ID_Table.[Household_ID] = {householdId} AND Participant_ID_Table_Contact_ID_Table_Household_Position_ID_Table.[Household_Position_ID] = 2 and Group_ID_Table_Group_Type_ID_Table.[Group_Type_ID] = 4";
+            return $"Participant_ID_Table_Contact_ID_Table_Household_ID_Table.[Household_ID] = {householdId} AND Participant_ID_Table_Contact_ID_Table_Household_Position_ID_Table.[Household_Position_ID] = 2 and Group_ID_Table_Group_Type_ID_Table.[Group_Type_ID] = 4 AND Group_Participants.[End_Date] IS NULL";
         }
 
         private static string GetChildParticpantsByOtherHouseholdFilter(int householdId)
@@ -558,7 +558,7 @@ namespace MinistryPlatform.Translation.Test.Repositories
 
         private static string GetChildParticpantsByGroupFilter(string participantIds)
         {
-            return $"Participant_ID_Table.[Participant_ID] IN ({participantIds}) AND Group_ID_Table_Congregation_ID_Table.[Congregation_ID] = 5 AND Group_ID_Table_Group_Type_ID_Table.[Group_Type_ID] = 4 AND Group_ID_Table_Ministry_ID_Table.[Ministry_ID] IN (2, 34)";
+            return $"Participant_ID_Table.[Participant_ID] IN ({participantIds}) AND Group_ID_Table_Congregation_ID_Table.[Congregation_ID] = 5 AND Group_ID_Table_Group_Type_ID_Table.[Group_Type_ID] = 4 AND Group_ID_Table_Ministry_ID_Table.[Ministry_ID] IN (2, 34) AND Group_Participants.[End_Date] IS NULL";
         }
     }
 }

--- a/SignInCheckIn/MinistryPlatform.Translation/Repositories/ChildSigninRepository.cs
+++ b/SignInCheckIn/MinistryPlatform.Translation/Repositories/ChildSigninRepository.cs
@@ -128,7 +128,7 @@ namespace MinistryPlatform.Translation.Repositories
             };
 
             var groupParticipants = _ministryPlatformRestRepository.UsingAuthenticationToken(apiUserToken).
-                        Search<MpGroupParticipantDto>($"Participant_ID_Table_Contact_ID_Table_Household_ID_Table.[Household_ID] = {householdId} AND Participant_ID_Table_Contact_ID_Table_Household_Position_ID_Table.[Household_Position_ID] = {_applicationConfiguration.MinorChildId} and Group_ID_Table_Group_Type_ID_Table.[Group_Type_ID] = {_applicationConfiguration.KidsClubGroupTypeId}", columnList).ToList();
+                        Search<MpGroupParticipantDto>($"Participant_ID_Table_Contact_ID_Table_Household_ID_Table.[Household_ID] = {householdId} AND Participant_ID_Table_Contact_ID_Table_Household_Position_ID_Table.[Household_Position_ID] = {_applicationConfiguration.MinorChildId} and Group_ID_Table_Group_Type_ID_Table.[Group_Type_ID] = {_applicationConfiguration.KidsClubGroupTypeId} AND Group_Participants.[End_Date] IS NULL", columnList).ToList();
 
             foreach (var g in groupParticipants)
             {
@@ -206,7 +206,7 @@ namespace MinistryPlatform.Translation.Repositories
 
             var participantIds = string.Join(",", children.Select(x => x.ParticipantId));
             var participants = _ministryPlatformRestRepository.UsingAuthenticationToken(apiUserToken).
-                        SearchTable<MpParticipantDto>("Group_Participants", $"Participant_ID_Table.[Participant_ID] IN ({participantIds}) AND Group_ID_Table_Congregation_ID_Table.[Congregation_ID] = {_applicationConfiguration.KidsClubCongregationId} AND Group_ID_Table_Group_Type_ID_Table.[Group_Type_ID] = {_applicationConfiguration.KidsClubGroupTypeId} AND Group_ID_Table_Ministry_ID_Table.[Ministry_ID] IN ({_applicationConfiguration.KidsClubMinistryId}, {_applicationConfiguration.StudentMinistryId})", columnList);
+                        SearchTable<MpParticipantDto>("Group_Participants", $"Participant_ID_Table.[Participant_ID] IN ({participantIds}) AND Group_ID_Table_Congregation_ID_Table.[Congregation_ID] = {_applicationConfiguration.KidsClubCongregationId} AND Group_ID_Table_Group_Type_ID_Table.[Group_Type_ID] = {_applicationConfiguration.KidsClubGroupTypeId} AND Group_ID_Table_Ministry_ID_Table.[Ministry_ID] IN ({_applicationConfiguration.KidsClubMinistryId}, {_applicationConfiguration.StudentMinistryId}) AND Group_Participants.[End_Date] IS NULL", columnList);
 
             children.ForEach(child =>
             {


### PR DESCRIPTION
**Rally:** https://rally1.rallydev.com/#/27593764268d/detail/defect/114403240476

**Build:** http://mp-ci.centralus.cloudapp.azure.com/viewType.html?buildTypeId=Code_Development_SignInCheckIn_Defect&branch_Code_Development_SignInCheckIn=defect%2FDE3455-SkipParticipantsGroupWithEndDateFamilyFinder&tab=buildTypeStatusDiv