### PR TITLE
Defect/de3847 template event maps

### DIFF
--- a/SignInCheckIn/MinistryPlatform.Translation.Test/Repositories/EventRepositoryTest.cs
+++ b/SignInCheckIn/MinistryPlatform.Translation.Test/Repositories/EventRepositoryTest.cs
@@ -107,7 +107,7 @@ namespace MinistryPlatform.Translation.Test.Repositories
             _ministryPlatformRestRepository.Setup(mocked => mocked.Search<MpEventDto>(It.IsAny<string>(), It.IsAny<List<string>>(), null, false)).Returns(mpEventDtos);
 
             // Act
-            _fixture.GetEventAndCheckinSubevents(token, eventId);
+            _fixture.GetEventAndCheckinSubevents(token, eventId, false);
 
             // Assert
             _ministryPlatformRestRepository.VerifyAll();

--- a/SignInCheckIn/MinistryPlatform.Translation/Repositories/EventRepository.cs
+++ b/SignInCheckIn/MinistryPlatform.Translation/Repositories/EventRepository.cs
@@ -178,12 +178,18 @@ namespace MinistryPlatform.Translation.Repositories
                 .PostStoredProc(ImportEventStoredProcedureName, new Dictionary<string, object> {{"@DestinationEventId", destinationEventId}, {"@SourceEventId", sourceEventId}});
         }
 
-        public List<MpEventDto> GetEventAndCheckinSubevents(string authenticationToken, int eventId)
+        public List<MpEventDto> GetEventAndCheckinSubevents(string authenticationToken, int eventId, bool excludeTemplates = true)
         {
             var token = authenticationToken ?? _apiUserRepository.GetToken();
+            var query = $"(Events.Event_ID = {eventId} OR Events.Parent_Event_ID = {eventId}) AND Events.[Allow_Check-in] = 1";
+            if (excludeTemplates == false)
+            {
+                query = $"{query} AND {nonEventTemplatesQueryString}";
+            }
+                
 
             return _ministryPlatformRestRepository.UsingAuthenticationToken(token)
-                .Search<MpEventDto>($"(Events.Event_ID = {eventId} OR Events.Parent_Event_ID = {eventId}) AND Events.[Allow_Check-in] = 1 AND {nonEventTemplatesQueryString}", _eventColumns);
+                .Search<MpEventDto>(query, _eventColumns);
         }
 
         public MpEventDto GetSubeventByParentEventId(int eventId, int eventTypeId)

--- a/SignInCheckIn/MinistryPlatform.Translation/Repositories/EventRepository.cs
+++ b/SignInCheckIn/MinistryPlatform.Translation/Repositories/EventRepository.cs
@@ -178,11 +178,11 @@ namespace MinistryPlatform.Translation.Repositories
                 .PostStoredProc(ImportEventStoredProcedureName, new Dictionary<string, object> {{"@DestinationEventId", destinationEventId}, {"@SourceEventId", sourceEventId}});
         }
 
-        public List<MpEventDto> GetEventAndCheckinSubevents(string authenticationToken, int eventId, bool excludeTemplates = true)
+        public List<MpEventDto> GetEventAndCheckinSubevents(string authenticationToken, int eventId, bool includeTemplates = false)
         {
             var token = authenticationToken ?? _apiUserRepository.GetToken();
             var query = $"(Events.Event_ID = {eventId} OR Events.Parent_Event_ID = {eventId}) AND Events.[Allow_Check-in] = 1";
-            if (excludeTemplates == false)
+            if (includeTemplates == false)
             {
                 query = $"{query} AND {nonEventTemplatesQueryString}";
             }

--- a/SignInCheckIn/MinistryPlatform.Translation/Repositories/Interfaces/IEventRepository.cs
+++ b/SignInCheckIn/MinistryPlatform.Translation/Repositories/Interfaces/IEventRepository.cs
@@ -20,7 +20,7 @@ namespace MinistryPlatform.Translation.Repositories.Interfaces
         void ResetEventSetup(string authenticationToken, int eventId);
         void ImportEventSetup(string authenticationToken, int destinationEventId, int sourceEventId);
         MpEventDto GetSubeventByParentEventId(int eventId, int eventTypeId);
-        List<MpEventDto> GetEventAndCheckinSubevents(string token, int eventId);
+        List<MpEventDto> GetEventAndCheckinSubevents(string token, int eventId, bool excludeTemplates = true);
         List<MpEventDto> GetSubeventsForEvents(List<int> eventIds, int? eventTypeId);
         MpEventDto GetSubeventByParentEventId(string token, int serviceEventId, int eventTypeId);
         List<MpEventGroupDto> GetEventGroupsByGroupIdAndEventIds(int groupId, List<int> eventIds);

--- a/SignInCheckIn/MinistryPlatform.Translation/Repositories/Interfaces/IEventRepository.cs
+++ b/SignInCheckIn/MinistryPlatform.Translation/Repositories/Interfaces/IEventRepository.cs
@@ -20,7 +20,7 @@ namespace MinistryPlatform.Translation.Repositories.Interfaces
         void ResetEventSetup(string authenticationToken, int eventId);
         void ImportEventSetup(string authenticationToken, int destinationEventId, int sourceEventId);
         MpEventDto GetSubeventByParentEventId(int eventId, int eventTypeId);
-        List<MpEventDto> GetEventAndCheckinSubevents(string token, int eventId, bool excludeTemplates = true);
+        List<MpEventDto> GetEventAndCheckinSubevents(string token, int eventId, bool includeTemplates = false);
         List<MpEventDto> GetSubeventsForEvents(List<int> eventIds, int? eventTypeId);
         MpEventDto GetSubeventByParentEventId(string token, int serviceEventId, int eventTypeId);
         List<MpEventGroupDto> GetEventGroupsByGroupIdAndEventIds(int groupId, List<int> eventIds);

--- a/SignInCheckIn/SignInCheckIn.Tests/Services/EventServiceTest.cs
+++ b/SignInCheckIn/SignInCheckIn.Tests/Services/EventServiceTest.cs
@@ -444,7 +444,7 @@ namespace SignInCheckIn.Tests.Services
                 EventTypeId = 20
             };
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId)).Returns(events);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(events);
             _eventRepository.Setup(m => m.CreateSubEvent(token, It.IsAny<MpEventDto>())).Returns(childEvent);
             _applicationConfiguation.Setup(m => m.AdventureClubEventTypeId).Returns(20);
 
@@ -481,7 +481,7 @@ namespace SignInCheckIn.Tests.Services
 
             events.Add(childEvent);
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId)).Returns(events);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(events);
             _applicationConfiguation.Setup(m => m.AdventureClubEventTypeId).Returns(20);
 
             // Act

--- a/SignInCheckIn/SignInCheckIn.Tests/Services/EventServiceTest.cs
+++ b/SignInCheckIn/SignInCheckIn.Tests/Services/EventServiceTest.cs
@@ -444,7 +444,7 @@ namespace SignInCheckIn.Tests.Services
                 EventTypeId = 20
             };
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(events);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, false)).Returns(events);
             _eventRepository.Setup(m => m.CreateSubEvent(token, It.IsAny<MpEventDto>())).Returns(childEvent);
             _applicationConfiguation.Setup(m => m.AdventureClubEventTypeId).Returns(20);
 
@@ -481,7 +481,7 @@ namespace SignInCheckIn.Tests.Services
 
             events.Add(childEvent);
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(events);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, false)).Returns(events);
             _applicationConfiguation.Setup(m => m.AdventureClubEventTypeId).Returns(20);
 
             // Act

--- a/SignInCheckIn/SignInCheckIn.Tests/Services/EventServiceTest.cs
+++ b/SignInCheckIn/SignInCheckIn.Tests/Services/EventServiceTest.cs
@@ -444,7 +444,7 @@ namespace SignInCheckIn.Tests.Services
                 EventTypeId = 20
             };
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, false)).Returns(events);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(events);
             _eventRepository.Setup(m => m.CreateSubEvent(token, It.IsAny<MpEventDto>())).Returns(childEvent);
             _applicationConfiguation.Setup(m => m.AdventureClubEventTypeId).Returns(20);
 
@@ -481,7 +481,7 @@ namespace SignInCheckIn.Tests.Services
 
             events.Add(childEvent);
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, false)).Returns(events);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(events);
             _applicationConfiguation.Setup(m => m.AdventureClubEventTypeId).Returns(20);
 
             // Act

--- a/SignInCheckIn/SignInCheckIn.Tests/Services/RoomServiceTest.cs
+++ b/SignInCheckIn/SignInCheckIn.Tests/Services/RoomServiceTest.cs
@@ -374,7 +374,7 @@ namespace SignInCheckIn.Tests.Services
 
             var checkinEvents = new List<MpEventDto>();
             checkinEvents.Add(mpEventDto);
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>())).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), false)).Returns(checkinEvents);
 
             _eventRepository.Setup(m => m.GetEventById(12345)).Returns(mpEventDto);
 
@@ -498,7 +498,7 @@ namespace SignInCheckIn.Tests.Services
                 }
             };
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), true)).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), false)).Returns(checkinEvents);
 
             _eventRepository.Setup(mocked => mocked.GetEventGroupsForEvent(eventId)).Returns(events);
             _groupRepository.Setup(mocked => mocked.GetGroups(token, It.IsAny<IEnumerable<int>>(), true)).Returns(new List<MpGroupDto>
@@ -561,7 +561,7 @@ namespace SignInCheckIn.Tests.Services
             var checkinEvents = new List<MpEventDto>();
             checkinEvents.Add(mpEventDto);
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), true)).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), false)).Returns(checkinEvents);
 
             _eventRepository.Setup(m => m.GetEventById(12345)).Returns(mpEventDto);
 
@@ -643,7 +643,7 @@ namespace SignInCheckIn.Tests.Services
             _attributeRepository.Setup(mocked => mocked.GetAttributesByAttributeTypeId(NurseryAgesAttributeTypeId, token))
                 .Returns(_nurseryMonthList.OrderBy(x => x.SortOrder).ToList());
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), true)).Returns(new List<MpEventDto>());
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), false)).Returns(new List<MpEventDto>());
 
             MpEventDto mpEventDto = new MpEventDto
             {
@@ -656,7 +656,7 @@ namespace SignInCheckIn.Tests.Services
             var checkinEvents = new List<MpEventDto>();
             checkinEvents.Add(mpEventDto);
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), true)).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), false)).Returns(checkinEvents);
 
             var events = new List<MpEventGroupDto>
             {
@@ -781,7 +781,7 @@ namespace SignInCheckIn.Tests.Services
                 }
             };
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, false)).Returns(checkinEvents);
             _roomRepository.Setup(m => m.GetEventRoomForEventMaps(It.IsAny<List<int>>(), 1111)).Returns(mpEventRoomFrom);
             _roomRepository.Setup(m => m.GetRoomsForEvent(mpEventDto.EventId, mpEventDto.LocationId)).Returns(mpEventRoomDtos);
             _roomRepository.Setup(m => m.GetBumpingRulesForEventRooms(It.IsAny<List<int?>>(), It.IsAny<int?>())).Returns(mpBumpingRuleDtos);
@@ -871,7 +871,7 @@ namespace SignInCheckIn.Tests.Services
                 RoomName = "name"
             };
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, false)).Returns(checkinEvents);
             _roomRepository.Setup(m => m.GetEventRoomForEventMaps(It.IsAny<List<int>>(), 1111)).Returns((MpEventRoomDto) null);
             _roomRepository.Setup(m => m.GetRoomsForEvent(mpEventDto.EventId, mpEventDto.LocationId)).Returns(mpEventRoomDtos);
             _roomRepository.Setup(m => m.GetBumpingRulesForEventRooms(It.IsAny<List<int?>>(), It.IsAny<int?>())).Returns(mpBumpingRuleDtos);
@@ -976,7 +976,7 @@ namespace SignInCheckIn.Tests.Services
 
 
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, false)).Returns(checkinEvents);
             _roomRepository.Setup(m => m.GetEventRoomForEventMaps(It.IsAny<List<int>>(), roomId)).Returns(mpEventRoomFrom);
             _roomRepository.Setup(m => m.GetRoomsForEvent(mpEventDto.EventId, mpEventDto.LocationId)).Returns(mpEventRoomDtos);
             _roomRepository.Setup(m => m.GetBumpingRulesByRoomId(1000)).Returns(mpBumpingRuleDtos);

--- a/SignInCheckIn/SignInCheckIn.Tests/Services/RoomServiceTest.cs
+++ b/SignInCheckIn/SignInCheckIn.Tests/Services/RoomServiceTest.cs
@@ -498,7 +498,7 @@ namespace SignInCheckIn.Tests.Services
                 }
             };
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>())).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), true)).Returns(checkinEvents);
 
             _eventRepository.Setup(mocked => mocked.GetEventGroupsForEvent(eventId)).Returns(events);
             _groupRepository.Setup(mocked => mocked.GetGroups(token, It.IsAny<IEnumerable<int>>(), true)).Returns(new List<MpGroupDto>
@@ -561,7 +561,7 @@ namespace SignInCheckIn.Tests.Services
             var checkinEvents = new List<MpEventDto>();
             checkinEvents.Add(mpEventDto);
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>())).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), true)).Returns(checkinEvents);
 
             _eventRepository.Setup(m => m.GetEventById(12345)).Returns(mpEventDto);
 
@@ -643,7 +643,7 @@ namespace SignInCheckIn.Tests.Services
             _attributeRepository.Setup(mocked => mocked.GetAttributesByAttributeTypeId(NurseryAgesAttributeTypeId, token))
                 .Returns(_nurseryMonthList.OrderBy(x => x.SortOrder).ToList());
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>())).Returns(new List<MpEventDto>());
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), true)).Returns(new List<MpEventDto>());
 
             MpEventDto mpEventDto = new MpEventDto
             {
@@ -656,7 +656,7 @@ namespace SignInCheckIn.Tests.Services
             var checkinEvents = new List<MpEventDto>();
             checkinEvents.Add(mpEventDto);
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>())).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(It.IsAny<string>(), It.IsAny<int>(), true)).Returns(checkinEvents);
 
             var events = new List<MpEventGroupDto>
             {
@@ -781,7 +781,7 @@ namespace SignInCheckIn.Tests.Services
                 }
             };
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId)).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(checkinEvents);
             _roomRepository.Setup(m => m.GetEventRoomForEventMaps(It.IsAny<List<int>>(), 1111)).Returns(mpEventRoomFrom);
             _roomRepository.Setup(m => m.GetRoomsForEvent(mpEventDto.EventId, mpEventDto.LocationId)).Returns(mpEventRoomDtos);
             _roomRepository.Setup(m => m.GetBumpingRulesForEventRooms(It.IsAny<List<int?>>(), It.IsAny<int?>())).Returns(mpBumpingRuleDtos);
@@ -871,7 +871,7 @@ namespace SignInCheckIn.Tests.Services
                 RoomName = "name"
             };
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId)).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(checkinEvents);
             _roomRepository.Setup(m => m.GetEventRoomForEventMaps(It.IsAny<List<int>>(), 1111)).Returns((MpEventRoomDto) null);
             _roomRepository.Setup(m => m.GetRoomsForEvent(mpEventDto.EventId, mpEventDto.LocationId)).Returns(mpEventRoomDtos);
             _roomRepository.Setup(m => m.GetBumpingRulesForEventRooms(It.IsAny<List<int?>>(), It.IsAny<int?>())).Returns(mpBumpingRuleDtos);
@@ -976,7 +976,7 @@ namespace SignInCheckIn.Tests.Services
 
 
 
-            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId)).Returns(checkinEvents);
+            _eventRepository.Setup(m => m.GetEventAndCheckinSubevents(token, eventId, true)).Returns(checkinEvents);
             _roomRepository.Setup(m => m.GetEventRoomForEventMaps(It.IsAny<List<int>>(), roomId)).Returns(mpEventRoomFrom);
             _roomRepository.Setup(m => m.GetRoomsForEvent(mpEventDto.EventId, mpEventDto.LocationId)).Returns(mpEventRoomDtos);
             _roomRepository.Setup(m => m.GetBumpingRulesByRoomId(1000)).Returns(mpBumpingRuleDtos);

--- a/SignInCheckIn/SignInCheckIn/Services/EventService.cs
+++ b/SignInCheckIn/SignInCheckIn/Services/EventService.cs
@@ -195,7 +195,7 @@ namespace SignInCheckIn.Services
         // upcoming refactor story - US6056
         public List<EventDto> GetEventMaps(string token, int eventId)
         {
-            var events = _eventRepository.GetEventAndCheckinSubevents(token, eventId);
+            var events = _eventRepository.GetEventAndCheckinSubevents(token, eventId, false);
             var parentEvent = events.First(r => r.ParentEventId == null);
 
             // 1. See if there's an existing AC subevent

--- a/SignInCheckIn/SignInCheckIn/Services/EventService.cs
+++ b/SignInCheckIn/SignInCheckIn/Services/EventService.cs
@@ -195,7 +195,7 @@ namespace SignInCheckIn.Services
         // upcoming refactor story - US6056
         public List<EventDto> GetEventMaps(string token, int eventId)
         {
-            var events = _eventRepository.GetEventAndCheckinSubevents(token, eventId, false);
+            var events = _eventRepository.GetEventAndCheckinSubevents(token, eventId, true);
             var parentEvent = events.First(r => r.ParentEventId == null);
 
             // 1. See if there's an existing AC subevent


### PR DESCRIPTION
adding optional parameter for whether to include template events in query, defaulting to false. We need these template events when getting event maps (/maps endpoint), but just in that one query in the endpoint.... so existing functionality elsewhere should stay the same (excluding template events)

build: https://goo.gl/F3vn3r