### PR TITLE
DE5004 Checkin Toggle

### DIFF
--- a/front_end/src/app/child-signin/serving/serving-toggle.component.html
+++ b/front_end/src/app/child-signin/serving/serving-toggle.component.html
@@ -1,7 +1,7 @@
 <label attr.for='isServing' class="text-xs-center pointer px-1 serving-label">
   <div class="serving-question-cont mt-2">
     <span class="tgl-inline-label tgl-serving-label">Are you serving today?</span>
-    <input class='tgl tgl-light' id='isServing' type='checkbox' [(ngModel)]="isServing" (click)="toggleServicesClick(showServiceSelectModal)">
+    <input class='tgl tgl-light' id='isServing' type='checkbox' [checked]="isServing" (click)="toggleServicesClick(showServiceSelectModal)">
     <label class='tgl-btn' for='isServing'>
       <span class="tgl-yes">Yes</span>
       <span class="tgl-no">No</span>


### PR DESCRIPTION
When toggling the serving opportunities toggle-switch on iOS during checkin, the toggle does not reflect an active state. 

This PR updates the checkbox element from a two-way `ngModel` binding to a one-way binding on the `checked` directive. This is apparently a known-issue in NG2 and doesn't appear to have any adverse implications in this context. 

Let me know if you have any concerns. 